### PR TITLE
Updating CMake. Deprecating GOOSEEYE_DEBUG

### DIFF
--- a/GooseEYEConfig.cmake
+++ b/GooseEYEConfig.cmake
@@ -23,7 +23,10 @@ include(CMakeFindDependencyMacro)
 
 if(NOT TARGET GooseEYE)
     include("${CMAKE_CURRENT_LIST_DIR}/GooseEYETargets.cmake")
-    get_target_property(GooseEYE_INCLUDE_DIRS GooseEYE INTERFACE_INCLUDE_DIRECTORIES)
+    get_target_property(
+        GooseEYE_INCLUDE_DIRS
+        GooseEYE
+        INTERFACE_INCLUDE_DIRECTORIES)
 endif()
 
 # Find dependencies
@@ -32,40 +35,42 @@ endif()
 find_dependency(xtensor)
 
 # Define support target "GooseEYE::compiler_warnings"
-# ===================================================
 
-if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_GREATER_EQUAL 3.11)
-    if(NOT TARGET GooseEYE::compiler_warnings)
-        add_library(GooseEYE::compiler_warnings INTERFACE IMPORTED)
-        if(MSVC)
-            target_compile_options(GooseEYE::compiler_warnings INTERFACE
-                /W4)
-        else()
-            target_compile_options(GooseEYE::compiler_warnings INTERFACE
-                -Wall
-                -Wextra
-                -pedantic
-                -Wno-unknown-pragmas)
-        endif()
+if(NOT TARGET GooseEYE::compiler_warnings)
+    add_library(GooseEYE::compiler_warnings INTERFACE IMPORTED)
+    if(MSVC)
+        set_property(
+            TARGET GooseEYE::compiler_warnings
+            PROPERTY INTERFACE_COMPILE_OPTIONS
+            /W4)
+    else()
+        set_property(
+            TARGET GooseEYE::compiler_warnings
+            PROPERTY INTERFACE_COMPILE_OPTIONS
+            -Wall
+            -Wextra
+            -pedantic
+            -Wno-unknown-pragmas)
     endif()
 endif()
 
 # Define support target "GooseEYE::assert"
-# ========================================
 
-if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_GREATER_EQUAL 3.11)
-    if(NOT TARGET GooseEYE::assert)
-        add_library(GooseEYE::assert INTERFACE IMPORTED)
-        target_compile_definitions(GooseEYE::assert INTERFACE GOOSEEYE_ENABLE_ASSERT)
-    endif()
+if(NOT TARGET GooseEYE::assert)
+    add_library(GooseEYE::assert INTERFACE IMPORTED)
+    set_property(
+        TARGET GooseEYE::assert
+        PROPERTY INTERFACE_COMPILE_DEFINITIONS
+        GOOSEEYE_ENABLE_ASSERT)
 endif()
 
 # Define support target "GooseEYE::debug"
-# =======================================
 
-if (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_GREATER_EQUAL 3.11)
-    if(NOT TARGET GooseEYE::debug)
-        add_library(GooseEYE::debug INTERFACE IMPORTED)
-        target_compile_definitions(GooseEYE::debug INTERFACE GOOSEEYE_DEBUG)
-    endif()
+if(NOT TARGET GooseEYE::debug)
+    add_library(GooseEYE::debug INTERFACE IMPORTED)
+    set_property(
+        TARGET GooseEYE::debug
+        PROPERTY INTERFACE_COMPILE_DEFINITIONS
+        XTENSOR_ENABLE_ASSERT
+        GOOSEEYE_ENABLE_ASSERT)
 endif()

--- a/docs/cpp_install.rst
+++ b/docs/cpp_install.rst
@@ -43,15 +43,22 @@ The following structure can be used for your project's ``CMakeLists.txt``:
         xtensor::optimize
         xtensor::use_xsimd)
 
-See the `documentation of xtensor <https://xtensor.readthedocs.io/en/latest/>`_ concerning optimisation.
+See the `documentation of xtensor <https://xtensor.readthedocs.io/en/latest/>`_
+concerning optimisation.
 
 .. note::
 
     There are additional targets available to expedite your ``CMakeLists.txt``:
 
-    *   ``GooseEYE::assert``: enable GooseEYE assertions.
-    *   ``GooseEYE::debug``: enable GooseEYE and xtensor assertions (slow).
-    *   ``GooseEYE::compiler_warnings``: enable compiler warnings.
+    *   ``GooseEYE::assert``:
+         enable GooseEYE assertions by defining ``GOOSEEYE_ENABLE_ASSERT``.
+
+    *   ``GooseEYE::debug``:
+         enable GooseEYE assertions by defining ``GOOSEEYE_ENABLE_ASSERT`` and
+         xtensor assertions by defining ``XTENSOR_ENABLE_ASSERT`` (slow).
+
+    *   ``GooseEYE::compiler_warnings``:
+         enable compiler warnings (generic).
 
 By hand
 ^^^^^^^

--- a/include/GooseEYE/config.h
+++ b/include/GooseEYE/config.h
@@ -7,22 +7,6 @@
 #ifndef GOOSEEYE_INCLUDE_H
 #define GOOSEEYE_INCLUDE_H
 
-// =================================================================================================
-
-#ifndef GOOSEEYE_DEBUG
-    #ifndef NDEBUG
-        #define NDEBUG
-    #endif
-#else
-    #ifndef GOOSEEYE_ENABLE_ASSERT
-        #define GOOSEEYE_ENABLE_ASSERT
-    #endif
-    #ifndef XTENSOR_ENABLE_ASSERT
-        #define XTENSOR_ENABLE_ASSERT
-    #endif
-#endif
-
-// =================================================================================================
 
 #define _USE_MATH_DEFINES
 


### PR DESCRIPTION
Instead of GOOSEEYE_DEBUG you should hand specify both GOOSEEYE_ENABLE_ASSERT and XTENSOR_ENABLE_ASSERT or use the CMake target GooseEYE::debug.

Fixes #51 . 